### PR TITLE
Add anchor-resource-constraints xslt

### DIFF
--- a/fixtures/sample--resource-constraints-inspire-license-spaces.xml
+++ b/fixtures/sample--resource-constraints-inspire-license-spaces.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:fra="http://www.cnig.gouv.fr/2005/fra"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>sample-id</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useConstraints>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+          </gmd:useConstraints>
+          <gmd:otherConstraints>
+            <gco:CharacterString>  Licence Ouverte  version   2.0</gco:CharacterString>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/fixtures/sample--resource-constraints-inspire-limitation-accents.xml
+++ b/fixtures/sample--resource-constraints-inspire-limitation-accents.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:fra="http://www.cnig.gouv.fr/2005/fra"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>sample-id</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useConstraints>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+          </gmd:useConstraints>
+          <gmd:otherConstraints>
+            <gco:CharacterString>Pas de restriction d'acces public</gco:CharacterString>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/fixtures/sample--resource-constraints-inspire-limitation-article13.xml
+++ b/fixtures/sample--resource-constraints-inspire-limitation-article13.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:fra="http://www.cnig.gouv.fr/2005/fra"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>sample-id</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useConstraints>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+          </gmd:useConstraints>
+          <gmd:otherConstraints>
+            <gco:CharacterString>L124-5-II-2 du code de l'environnement (Directive 2007/2/CE (INSPIRE), Article 13.1.c)</gco:CharacterString>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/fixtures/sample--resource-constraints-inspire-limitation-exact.xml
+++ b/fixtures/sample--resource-constraints-inspire-limitation-exact.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:fra="http://www.cnig.gouv.fr/2005/fra"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>sample-id</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useConstraints>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+          </gmd:useConstraints>
+          <gmd:otherConstraints>
+            <gco:CharacterString>Pas de restriction d'accès public</gco:CharacterString>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/fixtures/sample--resource-constraints-inspire-limitation-quotes.xml
+++ b/fixtures/sample--resource-constraints-inspire-limitation-quotes.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:fra="http://www.cnig.gouv.fr/2005/fra"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>sample-id</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useConstraints>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+          </gmd:useConstraints>
+          <gmd:otherConstraints>
+            <gco:CharacterString>Pas de restriction d’accès public</gco:CharacterString>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/fixtures/sample--resource-constraints-license-key.xml
+++ b/fixtures/sample--resource-constraints-license-key.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:fra="http://www.cnig.gouv.fr/2005/fra"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>sample-id</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useConstraints>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+          </gmd:useConstraints>
+          <gmd:otherConstraints>
+            <gco:CharacterString>etalab-2.0</gco:CharacterString>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/fixtures/sample--resource-constraints-license-label-and-url.xml
+++ b/fixtures/sample--resource-constraints-license-label-and-url.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:fra="http://www.cnig.gouv.fr/2005/fra"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>sample-id</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useConstraints>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+          </gmd:useConstraints>
+          <gmd:otherConstraints>
+            <gco:CharacterString>Licence Ouverte / Open Licence Version 2.0  https://www.etalab.gouv.fr/wp-content/uploads/2017/04/ETALAB-Licence-Ouverte-v2.0.pdf</gco:CharacterString>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/fixtures/sample--resource-constraints-license-label.xml
+++ b/fixtures/sample--resource-constraints-license-label.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:fra="http://www.cnig.gouv.fr/2005/fra"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>sample-id</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useConstraints>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+          </gmd:useConstraints>
+          <gmd:otherConstraints>
+            <gco:CharacterString>Licence Ouverte version 2.0</gco:CharacterString>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/fixtures/sample--resource-constraints-license-url.xml
+++ b/fixtures/sample--resource-constraints-license-url.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:fra="http://www.cnig.gouv.fr/2005/fra"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>sample-id</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useConstraints>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+          </gmd:useConstraints>
+          <gmd:otherConstraints>
+            <gco:CharacterString>https://www.etalab.gouv.fr/wp-content/uploads/2017/04/ETALAB-Licence-Ouverte-v2.0.pdf</gco:CharacterString>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/tests/anchor-resource-constraints.datara--89d278a5-ef6a-45a9-9ced-2b348a9963bb.xml
+++ b/tests/anchor-resource-constraints.datara--89d278a5-ef6a-45a9-9ced-2b348a9963bb.xml
@@ -1,0 +1,540 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:fra="http://www.cnig.gouv.fr/2005/fra"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+  <gmd:fileIdentifier>
+      <gco:CharacterString>89d278a5-ef6a-45a9-9ced-2b348a9963bb</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:language>
+      <gco:CharacterString>fre</gco:CharacterString>
+  </gmd:language>
+  <gmd:characterSet>
+      <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_CharacterSetCode"
+                               codeListValue="utf8"/>
+  </gmd:characterSet>
+  <gmd:hierarchyLevel>
+      <gmd:MD_ScopeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ScopeCode"
+                        codeListValue="dataset"/>
+  </gmd:hierarchyLevel>
+  <gmd:contact>
+      <gmd:CI_ResponsibleParty>
+         <gmd:individualName gco:nilReason="missing">
+            <gco:CharacterString/>
+         </gmd:individualName>
+         <gmd:organisationName>
+            <gco:CharacterString>Direction Régionale de l’Environnement de l’Aménagement et du Logement d'Auvergne-Rhône-Alpes (DREAL Auvergne-Rhône-Alpes)</gco:CharacterString>
+         </gmd:organisationName>
+         <gmd:positionName gco:nilReason="missing">
+            <gco:CharacterString/>
+         </gmd:positionName>
+         <gmd:contactInfo>
+            <gmd:CI_Contact>
+               <gmd:phone>
+                  <gmd:CI_Telephone>
+                     <gmd:voice gco:nilReason="missing">
+                        <gco:CharacterString/>
+                     </gmd:voice>
+                     <gmd:facsimile gco:nilReason="missing">
+                        <gco:CharacterString/>
+                     </gmd:facsimile>
+                  </gmd:CI_Telephone>
+               </gmd:phone>
+               <gmd:address>
+                  <gmd:CI_Address>
+                     <gmd:deliveryPoint gco:nilReason="missing">
+                        <gco:CharacterString/>
+                     </gmd:deliveryPoint>
+                     <gmd:city gco:nilReason="missing">
+                        <gco:CharacterString/>
+                     </gmd:city>
+                     <gmd:administrativeArea gco:nilReason="missing">
+                        <gco:CharacterString/>
+                     </gmd:administrativeArea>
+                     <gmd:postalCode gco:nilReason="missing">
+                        <gco:CharacterString/>
+                     </gmd:postalCode>
+                     <gmd:country gco:nilReason="missing">
+                        <gco:CharacterString/>
+                     </gmd:country>
+                     <gmd:electronicMailAddress>
+                        <gco:CharacterString>sig.dreal-ara@developpement-durable.gouv.fr</gco:CharacterString>
+                     </gmd:electronicMailAddress>
+                  </gmd:CI_Address>
+               </gmd:address>
+               <gmd:contactInstructions>
+                  <gmx:FileName src="https://admincarto.datara.gouv.fr/METADATA/documents/DREAL-ARA/DREAL_ARA.jpg">Logo</gmx:FileName>
+               </gmd:contactInstructions>
+            </gmd:CI_Contact>
+         </gmd:contactInfo>
+         <gmd:role>
+            <gmd:CI_RoleCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_RoleCode"
+                             codeListValue="resourceProvider"/>
+         </gmd:role>
+      </gmd:CI_ResponsibleParty>
+  </gmd:contact>
+  <gmd:dateStamp>
+      <gco:DateTime>2020-08-28T12:01:06</gco:DateTime>
+  </gmd:dateStamp>
+  <gmd:metadataStandardName>
+      <gco:CharacterString>ISO 19115:2003/19139</gco:CharacterString>
+  </gmd:metadataStandardName>
+  <gmd:metadataStandardVersion>
+      <gco:CharacterString>1.0</gco:CharacterString>
+  </gmd:metadataStandardVersion>
+  <gmd:referenceSystemInfo>
+      <gmd:MD_ReferenceSystem>
+         <gmd:referenceSystemIdentifier>
+            <gmd:RS_Identifier>
+               <gmd:code>
+                  <gco:CharacterString>RGF93 / Lambert-93 (EPSG:2154)</gco:CharacterString>
+               </gmd:code>
+               <gmd:codeSpace>
+                  <gco:CharacterString>EPSG</gco:CharacterString>
+               </gmd:codeSpace>
+               <gmd:version>
+                  <gco:CharacterString>7.4</gco:CharacterString>
+               </gmd:version>
+            </gmd:RS_Identifier>
+         </gmd:referenceSystemIdentifier>
+      </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:identificationInfo>
+      <gmd:MD_DataIdentification>
+         <gmd:citation>
+            <gmd:CI_Citation>
+               <gmd:title>
+                  <gco:CharacterString>Base Permanente de Equipements INSEE géolocalisés - Sport et loisir - Auvergne-Rhône-Alpes</gco:CharacterString>
+               </gmd:title>
+               <gmd:date>
+                  <gmd:CI_Date>
+                     <gmd:date>
+                        <gco:DateTime>2020-08-28T11:48:14</gco:DateTime>
+                     </gmd:date>
+                     <gmd:dateType>
+                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                                             codeListValue="revision"/>
+                     </gmd:dateType>
+                  </gmd:CI_Date>
+               </gmd:date>
+               <gmd:date>
+                  <gmd:CI_Date>
+                     <gmd:date>
+                        <gco:DateTime>2020-08-27T00:00:00</gco:DateTime>
+                     </gmd:date>
+                     <gmd:dateType>
+                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                                             codeListValue="publication"/>
+                     </gmd:dateType>
+                  </gmd:CI_Date>
+               </gmd:date>
+               <gmd:identifier>
+                  <gmd:MD_Identifier>
+                     <gmd:code>
+                        <gco:CharacterString>https://catalogue.datara.gouv.fr/geonetwork/srv/89d278a5-ef6a-45a9-9ced-2b348a9963bb</gco:CharacterString>
+                     </gmd:code>
+                  </gmd:MD_Identifier>
+               </gmd:identifier>
+            </gmd:CI_Citation>
+         </gmd:citation>
+         <gmd:abstract>
+            <gco:CharacterString>La base permanente des équipements (BPE) est une source statistique qui fournit le niveau d'équipements et de services rendus à la population sur un territoire. Les résultats sont proposés sous forme de bases de données dans différents formats et pour deux niveaux géographiques : les communes et les Iris. Depuis 2018, l'offre comprend également des bases de données où de nombreux équipements sont géolocalisés. La présente table est une ré-utilisation faite par la DREAL ARA pour usage dans DATARA avec la géolocalisation des équipements sportifs et de loisir. Cette table présente  les équipements sportifs et de loisir. La précision du géocodage est la suivante : 
+
+Bonne	21 929 équipements 
+Acceptable	15 équipements  
+centre iris	 35 équipements 
+Mauvaise	 75 équipements 
+centre commune	69 équipements 
+
+les tableurs sources sont ici
+https://www.insee.fr/fr/statistiques/3568638?sommaire=3568656</gco:CharacterString>
+         </gmd:abstract>
+         <gmd:pointOfContact>
+            <gmd:CI_ResponsibleParty>
+               <gmd:individualName gco:nilReason="missing">
+                  <gco:CharacterString/>
+               </gmd:individualName>
+               <gmd:organisationName>
+                  <gco:CharacterString>Direction Régionale de l’Environnement de l’Aménagement et du Logement d'Auvergne-Rhône-Alpes (DREAL Auvergne-Rhône-Alpes)</gco:CharacterString>
+               </gmd:organisationName>
+               <gmd:contactInfo>
+                  <gmd:CI_Contact>
+                     <gmd:phone>
+                        <gmd:CI_Telephone>
+                           <gmd:voice gco:nilReason="missing">
+                              <gco:CharacterString/>
+                           </gmd:voice>
+                        </gmd:CI_Telephone>
+                     </gmd:phone>
+                     <gmd:address>
+                        <gmd:CI_Address>
+                           <gmd:electronicMailAddress>
+                              <gco:CharacterString>sig.dreal-ara@developpement-durable.gouv.fr</gco:CharacterString>
+                           </gmd:electronicMailAddress>
+                        </gmd:CI_Address>
+                     </gmd:address>
+                     <gmd:contactInstructions>
+                        <gmx:FileName src="https://admincarto.datara.gouv.fr/METADATA/documents/DREAL-ARA/DREAL_ARA.jpg">Logo</gmx:FileName>
+                     </gmd:contactInstructions>
+                  </gmd:CI_Contact>
+               </gmd:contactInfo>
+               <gmd:role>
+                  <gmd:CI_RoleCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_RoleCode"
+                                   codeListValue="user"/>
+               </gmd:role>
+            </gmd:CI_ResponsibleParty>
+         </gmd:pointOfContact>
+         <gmd:pointOfContact>
+            <gmd:CI_ResponsibleParty>
+               <gmd:individualName gco:nilReason="missing">
+                  <gco:CharacterString/>
+               </gmd:individualName>
+               <gmd:organisationName>
+                  <gco:CharacterString>Institut national de la statistique et des études économiques (INSEE)</gco:CharacterString>
+               </gmd:organisationName>
+               <gmd:contactInfo>
+                  <gmd:CI_Contact>
+                     <gmd:address>
+                        <gmd:CI_Address>
+                           <gmd:electronicMailAddress>
+                              <gco:CharacterString>https://www.insee.fr/fr/information/1912226</gco:CharacterString>
+                           </gmd:electronicMailAddress>
+                        </gmd:CI_Address>
+                     </gmd:address>
+                  </gmd:CI_Contact>
+               </gmd:contactInfo>
+               <gmd:role>
+                  <gmd:CI_RoleCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_RoleCode"
+                                   codeListValue="owner"/>
+               </gmd:role>
+            </gmd:CI_ResponsibleParty>
+         </gmd:pointOfContact>
+         <gmd:graphicOverview>
+            <gmd:MD_BrowseGraphic>
+               <gmd:fileName>
+                  <gco:CharacterString>https://catalogue.datara.gouv.fr/thumbnails/89d278a5-ef6a-45a9-9ced-2b348a9963bb.png</gco:CharacterString>
+               </gmd:fileName>
+               <gmd:fileDescription>
+                  <gco:CharacterString>Aperçu</gco:CharacterString>
+               </gmd:fileDescription>
+            </gmd:MD_BrowseGraphic>
+         </gmd:graphicOverview>
+         <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+               <gmd:keyword>
+                  <gco:CharacterString>Auvergne-Rhône-Alpes</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:type>
+                  <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_KeywordTypeCode"
+                                          codeListValue="place"/>
+               </gmd:type>
+            </gmd:MD_Keywords>
+         </gmd:descriptiveKeywords>
+         <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+               <gmd:keyword>
+                  <gco:CharacterString>AUVERGNE-RHONE-ALPES</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:type>
+                  <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_KeywordTypeCode"
+                                          codeListValue="place"/>
+               </gmd:type>
+               <gmd:thesaurusName>
+                  <gmd:CI_Citation>
+                     <gmd:title>
+                        <gco:CharacterString>NouvellesRegionAdminExpress</gco:CharacterString>
+                     </gmd:title>
+                     <gmd:date>
+                        <gmd:CI_Date>
+                           <gmd:date>
+                              <gco:Date>2006-09-22</gco:Date>
+                           </gmd:date>
+                           <gmd:dateType>
+                              <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                                                   codeListValue="publication"/>
+                           </gmd:dateType>
+                        </gmd:CI_Date>
+                     </gmd:date>
+                     <gmd:identifier>
+                        <gmd:MD_Identifier>
+                           <gmd:code>
+                              <gmx:Anchor xlink:href="https://catalogue.datara.gouv.fr/geonetwork/srv/fre/thesaurus.download?ref=external.place.region_adminexp_s_000">geonetwork.thesaurus.external.place.region_adminexp_s_000</gmx:Anchor>
+                           </gmd:code>
+                        </gmd:MD_Identifier>
+                     </gmd:identifier>
+                  </gmd:CI_Citation>
+               </gmd:thesaurusName>
+            </gmd:MD_Keywords>
+         </gmd:descriptiveKeywords>
+         <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+               <gmd:keyword>
+                  <gco:CharacterString>Services d'utilité publique et services publics</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:type>
+                  <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_KeywordTypeCode"
+                                          codeListValue="theme"/>
+               </gmd:type>
+               <gmd:thesaurusName>
+                  <gmd:CI_Citation>
+                     <gmd:title>
+                        <gco:CharacterString>GEMET - INSPIRE themes, version 1.0</gco:CharacterString>
+                     </gmd:title>
+                     <gmd:date>
+                        <gmd:CI_Date>
+                           <gmd:date>
+                              <gco:Date>2008-06-01</gco:Date>
+                           </gmd:date>
+                           <gmd:dateType>
+                              <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                                                   codeListValue="publication"/>
+                           </gmd:dateType>
+                        </gmd:CI_Date>
+                     </gmd:date>
+                     <gmd:identifier>
+                        <gmd:MD_Identifier>
+                           <gmd:code>
+                              <gmx:Anchor xlink:href="https://catalogue.datara.gouv.fr/geonetwork/srv/fre/thesaurus.download?ref=external.theme.inspire-theme">geonetwork.thesaurus.external.theme.inspire-theme</gmx:Anchor>
+                           </gmd:code>
+                        </gmd:MD_Identifier>
+                     </gmd:identifier>
+                  </gmd:CI_Citation>
+               </gmd:thesaurusName>
+            </gmd:MD_Keywords>
+         </gmd:descriptiveKeywords>
+         <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+               <gmd:keyword>
+                  <gco:CharacterString>Sport</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:keyword>
+                  <gco:CharacterString>DREAL Auvergne-Rhône-Alpes</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:keyword>
+                  <gco:CharacterString>Grand public</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:type>
+                  <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode"
+                                          codeListValue="theme"/>
+               </gmd:type>
+               <gmd:thesaurusName>
+                  <gmd:CI_Citation>
+                     <gmd:title>
+                        <gco:CharacterString>Domaines</gco:CharacterString>
+                     </gmd:title>
+                     <gmd:date>
+                        <gmd:CI_Date>
+                           <gmd:date>
+                              <gco:Date>2024-05-23</gco:Date>
+                           </gmd:date>
+                           <gmd:dateType>
+                              <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                                                   codeListValue="publication"/>
+                           </gmd:dateType>
+                        </gmd:CI_Date>
+                     </gmd:date>
+                     <gmd:identifier>
+                        <gmd:MD_Identifier>
+                           <gmd:code>
+                              <gmx:Anchor xlink:href="https://catalogue.datara.gouv.fr/geonetwork/srv/fre/thesaurus.download?ref=external.theme.prodige">
+                    geonetwork.thesaurus.external.theme.prodige</gmx:Anchor>
+                           </gmd:code>
+                        </gmd:MD_Identifier>
+                     </gmd:identifier>
+                  </gmd:CI_Citation>
+               </gmd:thesaurusName>
+            </gmd:MD_Keywords>
+         </gmd:descriptiveKeywords>
+         <gmd:resourceConstraints>
+            <gmd:MD_LegalConstraints>
+               <gmd:useLimitation>
+                  <gco:CharacterString>Utilisation libre sous réserve de mentionner la source (a minima le nom du producteur) et la date de sa dernière mise à jour</gco:CharacterString>
+               </gmd:useLimitation>
+               <gmd:accessConstraints>
+                  <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode"
+                                          codeListValue="otherRestrictions"/>
+               </gmd:accessConstraints>
+               <gmd:useConstraints>
+                  <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode"
+                                          codeListValue="otherRestrictions"/>
+               </gmd:useConstraints>
+               <gmd:otherConstraints>
+                  <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">Pas de restriction d’accès public selon INSPIRE</gmx:Anchor>
+               </gmd:otherConstraints>
+            </gmd:MD_LegalConstraints>
+         </gmd:resourceConstraints>
+         <gmd:spatialRepresentationType>
+            <gmd:MD_SpatialRepresentationTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_SpatialRepresentationTypeCode"
+                                                  codeListValue="vector"/>
+         </gmd:spatialRepresentationType>
+         <gmd:spatialResolution>
+            <gmd:MD_Resolution>
+               <gmd:equivalentScale>
+                  <gmd:MD_RepresentativeFraction>
+                     <gmd:denominator>
+                        <gco:Integer>50000</gco:Integer>
+                     </gmd:denominator>
+                  </gmd:MD_RepresentativeFraction>
+               </gmd:equivalentScale>
+            </gmd:MD_Resolution>
+         </gmd:spatialResolution>
+         <gmd:language>
+            <gco:CharacterString>fre</gco:CharacterString>
+         </gmd:language>
+         <gmd:characterSet>
+            <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_CharacterSetCode"
+                                     codeListValue="utf8"/>
+         </gmd:characterSet>
+         <gmd:topicCategory>
+            <gmd:MD_TopicCategoryCode>utilitiesCommunication</gmd:MD_TopicCategoryCode>
+         </gmd:topicCategory>
+         <gmd:extent xmlns:srv="http://www.isotc211.org/2005/srv">
+            <gmd:EX_Extent xmlns:xs="http://www.w3.org/2001/XMLSchema">
+               <gmd:description>
+                  <gco:CharacterString>AUVERGNE-RHONE-ALPES</gco:CharacterString>
+               </gmd:description>
+               <gmd:geographicElement>
+                  <gmd:EX_GeographicBoundingBox>
+                     <gmd:westBoundLongitude>
+                        <gco:Decimal>2.0629141330719</gco:Decimal>
+                     </gmd:westBoundLongitude>
+                     <gmd:eastBoundLongitude>
+                        <gco:Decimal>7.18588781356812</gco:Decimal>
+                     </gmd:eastBoundLongitude>
+                     <gmd:southBoundLatitude>
+                        <gco:Decimal>44.1153793334961</gco:Decimal>
+                     </gmd:southBoundLatitude>
+                     <gmd:northBoundLatitude>
+                        <gco:Decimal>46.8040313720703</gco:Decimal>
+                     </gmd:northBoundLatitude>
+                  </gmd:EX_GeographicBoundingBox>
+               </gmd:geographicElement>
+            </gmd:EX_Extent>
+         </gmd:extent>
+      </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmd:contentInfo>
+      <gmd:MD_FeatureCatalogueDescription>
+         <gmd:includedWithDataset/>
+         <gmd:featureCatalogueCitation uuidref="d3b22b85-a59a-4fa0-b24d-4f11a8ee1cf7"
+                                       xlink:href="https://catalogue.datara.gouv.fr/geonetwork/srv/fre/csw?service=CSW&amp;request=GetRecordById&amp;version=2.0.2&amp;outputSchema=http://www.isotc211.org/2005/gmd&amp;elementSetName=full&amp;id=d3b22b85-a59a-4fa0-b24d-4f11a8ee1cf7"/>
+      </gmd:MD_FeatureCatalogueDescription>
+  </gmd:contentInfo>
+  <gmd:distributionInfo>
+      <gmd:MD_Distribution>
+         <gmd:distributionFormat>
+            <gmd:MD_Format>
+               <gmd:name>
+                  <gco:CharacterString>ZIP</gco:CharacterString>
+               </gmd:name>
+               <gmd:version gco:nilReason="unknown">
+                  <gco:CharacterString/>
+               </gmd:version>
+            </gmd:MD_Format>
+         </gmd:distributionFormat>
+         <gmd:transferOptions>
+            <gmd:MD_DigitalTransferOptions>
+          
+               <gmd:onLine>
+                  <gmd:CI_OnlineResource>
+                     <gmd:linkage>
+                        <gmd:URL>https://catalogue.datara.gouv.fr/rss/atomfeed/atomdataset/89d278a5-ef6a-45a9-9ced-2b348a9963bb</gmd:URL>
+                     </gmd:linkage>
+                     <gmd:protocol>
+                        <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+                     </gmd:protocol>
+                     <gmd:name>
+                        <gco:CharacterString>Accès au lien ATOM de téléchargement</gco:CharacterString>
+                     </gmd:name>
+                  </gmd:CI_OnlineResource>
+               </gmd:onLine>
+               <gmd:onLine>
+                  <gmd:CI_OnlineResource>
+                     <gmd:linkage>
+                        <gmd:URL>https://catalogue.datara.gouv.fr/geosource/panierDownloadFrontalParametrage?LAYERIDTS=54174197</gmd:URL>
+                     </gmd:linkage>
+                     <gmd:protocol>
+                        <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
+                     </gmd:protocol>
+                     <gmd:name>
+                        <gco:CharacterString>Accès au téléchargement des données</gco:CharacterString>
+                     </gmd:name>
+                  </gmd:CI_OnlineResource>
+               </gmd:onLine>
+               <gmd:onLine>
+                  <gmd:CI_OnlineResource>
+                     <gmd:linkage>
+                        <gmd:URL>https://catalogue.datara.gouv.fr/geosource/consultationWMS?IDT=54174197</gmd:URL>
+                     </gmd:linkage>
+                     <gmd:protocol>
+                        <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+                     </gmd:protocol>
+                     <gmd:name>
+                        <gco:CharacterString>Accès à la visualisation des données</gco:CharacterString>
+                     </gmd:name>
+                     <gmd:applicationProfile>
+                        <gco:CharacterString>MAP</gco:CharacterString>
+                     </gmd:applicationProfile>
+                  </gmd:CI_OnlineResource>
+               </gmd:onLine>
+            </gmd:MD_DigitalTransferOptions>
+         </gmd:transferOptions>
+      </gmd:MD_Distribution>
+  </gmd:distributionInfo>
+  <gmd:dataQualityInfo>
+      <gmd:DQ_DataQuality>
+         <gmd:scope>
+            <gmd:DQ_Scope>
+               <gmd:level>
+                  <gmd:MD_ScopeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ScopeCode"
+                                    codeListValue="dataset"/>
+               </gmd:level>
+            </gmd:DQ_Scope>
+         </gmd:scope>
+         <gmd:report>
+            <gmd:DQ_DomainConsistency>
+               <gmd:result>
+                  <gmd:DQ_ConformanceResult>
+                     <gmd:specification>
+                        <gmd:CI_Citation>
+                           <gmd:title>
+                              <gco:CharacterString>spécification locale</gco:CharacterString>
+                           </gmd:title>
+                           <gmd:date>
+                              <gmd:CI_Date>
+                                 <gmd:date>
+                                    <gco:Date>2019-04-11</gco:Date>
+                                 </gmd:date>
+                                 <gmd:dateType>
+                                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
+                                                         codeListValue="creation"/>
+                                 </gmd:dateType>
+                              </gmd:CI_Date>
+                           </gmd:date>
+                        </gmd:CI_Citation>
+                     </gmd:specification>
+                     <gmd:explanation gco:nilReason="missing">
+                        <gco:CharacterString/>
+                     </gmd:explanation>
+                     <gmd:pass>
+                        <gco:Boolean>true</gco:Boolean>
+                     </gmd:pass>
+                  </gmd:DQ_ConformanceResult>
+               </gmd:result>
+            </gmd:DQ_DomainConsistency>
+         </gmd:report>
+         <gmd:lineage>
+            <gmd:LI_Lineage>
+               <gmd:statement>
+                  <gco:CharacterString>Traitement des tableurs INSEE pour usage facile dans DATARA; filtrages sous Talend puis requetes dans PostGreSQL pour affecter les coordonnées des centres des iris ou des communes aux équipements non géolocalisés</gco:CharacterString>
+               </gmd:statement>
+            </gmd:LI_Lineage>
+         </gmd:lineage>
+      </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
+</gmd:MD_Metadata>

--- a/tests/anchor-resource-constraints.datara--89d278a5-ef6a-45a9-9ced-2b348a9963bb.xml
+++ b/tests/anchor-resource-constraints.datara--89d278a5-ef6a-45a9-9ced-2b348a9963bb.xml
@@ -364,7 +364,7 @@ https://www.insee.fr/fr/statistiques/3568638?sommaire=3568656</gco:CharacterStri
                                           codeListValue="otherRestrictions"/>
                </gmd:useConstraints>
                <gmd:otherConstraints>
-                  <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">Pas de restriction d’accès public selon INSPIRE</gmx:Anchor>
+                  <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">Pas de restriction d'accès public</gmx:Anchor>
                </gmd:otherConstraints>
             </gmd:MD_LegalConstraints>
          </gmd:resourceConstraints>

--- a/tests/anchor-resource-constraints.sample--resource-constraints-inspire-license-spaces.xml
+++ b/tests/anchor-resource-constraints.sample--resource-constraints-inspire-license-spaces.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:fra="http://www.cnig.gouv.fr/2005/fra"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>sample-id</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useConstraints>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+          </gmd:useConstraints>
+          <gmd:otherConstraints>
+            <gmx:Anchor xlink:href="https://spdx.org/licenses/etalab-2.0">Licence Ouverte / Open Licence version 2.0</gmx:Anchor>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/tests/anchor-resource-constraints.sample--resource-constraints-inspire-limitation-accents.xml
+++ b/tests/anchor-resource-constraints.sample--resource-constraints-inspire-limitation-accents.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:fra="http://www.cnig.gouv.fr/2005/fra"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>sample-id</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useConstraints>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+          </gmd:useConstraints>
+          <gmd:otherConstraints>
+            <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">Pas de restriction d'accès public</gmx:Anchor>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/tests/anchor-resource-constraints.sample--resource-constraints-inspire-limitation-article13.xml
+++ b/tests/anchor-resource-constraints.sample--resource-constraints-inspire-limitation-article13.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:fra="http://www.cnig.gouv.fr/2005/fra"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>sample-id</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useConstraints>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+          </gmd:useConstraints>
+          <gmd:otherConstraints>
+            <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/INSPIRE_Directive_Article13_1c">L124-5-II-2 du code de l'environnement (Directive 2007/2/CE (INSPIRE), Article 13.1.c)</gmx:Anchor>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/tests/anchor-resource-constraints.sample--resource-constraints-inspire-limitation-exact.xml
+++ b/tests/anchor-resource-constraints.sample--resource-constraints-inspire-limitation-exact.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:fra="http://www.cnig.gouv.fr/2005/fra"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>sample-id</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useConstraints>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+          </gmd:useConstraints>
+          <gmd:otherConstraints>
+            <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">Pas de restriction d'accès public</gmx:Anchor>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/tests/anchor-resource-constraints.sample--resource-constraints-inspire-limitation-quotes.xml
+++ b/tests/anchor-resource-constraints.sample--resource-constraints-inspire-limitation-quotes.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:fra="http://www.cnig.gouv.fr/2005/fra"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>sample-id</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useConstraints>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+          </gmd:useConstraints>
+          <gmd:otherConstraints>
+            <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">Pas de restriction d'accès public</gmx:Anchor>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/tests/anchor-resource-constraints.sample--resource-constraints-license-key.xml
+++ b/tests/anchor-resource-constraints.sample--resource-constraints-license-key.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:fra="http://www.cnig.gouv.fr/2005/fra"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>sample-id</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useConstraints>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+          </gmd:useConstraints>
+          <gmd:otherConstraints>
+            <gmx:Anchor xlink:href="https://spdx.org/licenses/etalab-2.0">Licence Ouverte / Open Licence version 2.0</gmx:Anchor>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/tests/anchor-resource-constraints.sample--resource-constraints-license-label-and-url.xml
+++ b/tests/anchor-resource-constraints.sample--resource-constraints-license-label-and-url.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:fra="http://www.cnig.gouv.fr/2005/fra"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>sample-id</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useConstraints>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+          </gmd:useConstraints>
+          <gmd:otherConstraints>
+            <gmx:Anchor xlink:href="https://spdx.org/licenses/etalab-2.0">Licence Ouverte / Open Licence version 2.0</gmx:Anchor>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/tests/anchor-resource-constraints.sample--resource-constraints-license-label.xml
+++ b/tests/anchor-resource-constraints.sample--resource-constraints-license-label.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:fra="http://www.cnig.gouv.fr/2005/fra"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>sample-id</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useConstraints>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+          </gmd:useConstraints>
+          <gmd:otherConstraints>
+            <gmx:Anchor xlink:href="https://spdx.org/licenses/etalab-2.0">Licence Ouverte / Open Licence version 2.0</gmx:Anchor>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/tests/anchor-resource-constraints.sample--resource-constraints-license-url.xml
+++ b/tests/anchor-resource-constraints.sample--resource-constraints-license-url.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:fra="http://www.cnig.gouv.fr/2005/fra"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gts="http://www.isotc211.org/2005/gts"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>sample-id</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useConstraints>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+          </gmd:useConstraints>
+          <gmd:otherConstraints>
+            <gmx:Anchor xlink:href="https://spdx.org/licenses/etalab-2.0">Licence Ouverte / Open Licence version 2.0</gmx:Anchor>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/xslts/anchor-resource-constraints.xsl
+++ b/xslts/anchor-resource-constraints.xsl
@@ -91,7 +91,10 @@ https://ecospheres.gitbook.io/recommandations-iso-dcat/adaptation-des-metadonnee
         <item>
           <key>noLimitations</key>
           <label>Pas de restriction d'accès public</label>
+          <alt>Pas de restriction d'accès publique</alt>
+          <alt>Pas de restriction d'accès au public</alt>
           <alt>Pas de restriction d'accès public selon INSPIRE</alt>
+          <alt>Directive 2007/2/CE (INSPIRE), pas de restriction d'accès public</alt>
         </item>
         <item>
           <key>INSPIRE_Directive_Article13_1a</key>
@@ -136,11 +139,11 @@ https://ecospheres.gitbook.io/recommandations-iso-dcat/adaptation-des-metadonnee
       <xsl:with-param name="entries">
         <item>
           <key>noConditionsApply</key>
-          <label>aucune condition ne s'applique</label>
+          <label>Aucune condition ne s'applique</label>
         </item>
         <item>
           <key>conditionsUnknown</key>
-          <label>conditions inconnues</label>
+          <label>Conditions inconnues</label>
         </item>
       </xsl:with-param>
     </xsl:call-template>

--- a/xslts/anchor-resource-constraints.xsl
+++ b/xslts/anchor-resource-constraints.xsl
@@ -1,0 +1,322 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Convertit le texte libre d'une otherRestrictions en gmx:Anchor lorsqu'il n'y a pas d'ambiguité.
+
+https://ecospheres.gitbook.io/recommandations-iso-dcat/adaptation-des-metadonnees-iso-19139-pour-faciliter-la-transformation-en-dcat/faciliter-la-reconnaissance-des-licences
+-->
+
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:exsl="http://exslt.org/common"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                extension-element-prefixes="exsl"
+                exclude-result-prefixes="#all">
+
+  <!--
+      Text-to-anchor mappings
+  -->
+
+  <!-- Licenses -->
+  <xsl:variable name="licenses">
+    <xsl:call-template name="build-registry-lookup">
+      <xsl:with-param name="base-uri" select="'https://spdx.org/licenses'"/>
+      <xsl:with-param name="entries">
+        <!--
+            Partly generated from:
+            curl -s 'https://www.data.gouv.fr/api/1/datasets/licenses/' \
+            | jq -r '.[] | select(.id=="lov2") | .title,.alternate_titles[],.url,.alternate_urls[] | "<alt>\(.)</alt>"'
+        -->
+        <item>
+          <key>etalab-2.0</key>
+          <label>Licence Ouverte / Open Licence version 2.0</label>
+          <alt>Licence Ouverte (Etalab)</alt>
+          <alt>Licence Ouverte / Open Licence v2.0</alt>
+          <alt>Licence Ouverte / Open Licence v2</alt>
+          <alt>Licence Ouverte / Open Licence version 2.0</alt>
+          <alt>Licence Ouverte / Open Licence version 2.0</alt>
+          <alt>Licence Ouverte v2.0 (Etalab)</alt>
+          <alt>Licence Ouverte v2.0</alt>
+          <alt>Licence Ouverte v2</alt>
+          <alt>Licence Ouverte version 2.0</alt>
+          <alt>License Etalab v2.0</alt>
+          <alt>License Etalab v2</alt>
+          <alt>License Etalab version 2.0</alt>
+          <alt>License Etalab</alt>
+          <alt>License Ouverte</alt>
+          <alt>Open Licence v2.0</alt>
+          <alt>Open Licence v2</alt>
+          <alt>Open Licence version 2.0</alt>
+          <alt>https://github.com/DISIC/politique-de-contribution-open-source/blob/master/LICENSE.pdf</alt>
+          <alt>https://github.com/etalab/Licence-Ouverte/blob/master/LO.md</alt>
+          <alt>https://raw.githubusercontent.com/DISIC/politique-de-contribution-open-source/master/LICENSE</alt>
+          <alt>https://spdx.org/licenses/etalab-2.0.html</alt>
+          <alt>https://spdx.org/licenses/etalab-2.0</alt>
+          <alt>https://www.etalab.gouv.fr/licence-ouverte-open-licence</alt>
+          <alt>https://www.etalab.gouv.fr/wp-content/uploads/2017/04/ETALAB-Licence-Ouverte-v2.0.pdf</alt>
+        </item>
+        <item>
+          <key>ODbL-1.0</key>
+          <label>Open Data Commons Open Database License v1.0</label>
+          <alt>Open Data Commons Open Database License (ODbL) 1.0</alt>
+          <alt>Open Data Commons Open Database License (ODbL) v1.0</alt>
+          <alt>Open Data Commons Open Database License (ODbL) version 1.0</alt>
+          <alt>Open Data Commons Open Database License (ODbL)</alt>
+          <alt>Open Data Commons Open Database License 1.0</alt>
+          <alt>Open Data Commons Open Database License v1.0</alt>
+          <alt>Open Data Commons Open Database License version 1.0</alt>
+          <alt>Open Database License (ODbL) 1.0</alt>
+          <alt>Open Database License (ODbL) v1.0</alt>
+          <alt>Open Database License (ODbL) version 1.0</alt>
+          <alt>Open Database License (ODbL)</alt>
+          <alt>Open Database License</alt>
+          <alt>http://opendatacommons.org/licenses/odbl/summary/</alt>
+          <alt>http://www.opendatacommons.org/licenses/odbl/1.0/</alt>
+          <alt>https://opendatacommons.org/licenses/odbl/1-0/</alt>
+          <alt>https://opendefinition.org/licenses/odc-odbl</alt>
+          <alt>https://spdx.org/licenses/ODbL-1.0.html</alt>
+          <alt>https://spdx.org/licenses/ODbL-1.0</alt>
+        </item>
+      </xsl:with-param>
+    </xsl:call-template>
+  </xsl:variable>
+
+  <!-- INSPIRE LimitationsOnPublicAccess -->
+  <xsl:variable name="limitations">
+    <xsl:call-template name="build-registry-lookup">
+      <xsl:with-param name="base-uri" select="'http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess'"/>
+      <xsl:with-param name="entries">
+        <item>
+          <key>noLimitations</key>
+          <label>Pas de restriction d'accès public</label>
+          <alt>Pas de restriction d'accès public selon INSPIRE</alt>
+        </item>
+        <item>
+          <key>INSPIRE_Directive_Article13_1a</key>
+          <label>L124-4-I-1 du code de l'environnement (Directive 2007/2/CE (INSPIRE), Article 13.1.a)</label>
+        </item>
+        <item>
+          <key>INSPIRE_Directive_Article13_1b</key>
+          <label>L124-5-II-1 du code de l'environnement (Directive 2007/2/CE (INSPIRE), Article 13.1.b)</label>
+        </item>
+        <item>
+          <key>INSPIRE_Directive_Article13_1c</key>
+          <label>L124-5-II-2 du code de l'environnement (Directive 2007/2/CE (INSPIRE), Article 13.1.c)</label>
+        </item>
+        <item>
+          <key>INSPIRE_Directive_Article13_1d</key>
+          <label>L124-5-II-2 du code de l'environnement (Directive 2007/2/CE (INSPIRE), Article 13.1.c)</label>
+        </item>
+        <item>
+          <key>INSPIRE_Directive_Article13_1e</key>
+          <label>L124-5-II-3 du code de l'environnement (Directive 2007/2/CE (INSPIRE), Article 13.1.e)</label>
+        </item>
+        <item>
+          <key>INSPIRE_Directive_Article13_1f</key>
+          <label>L124-4-I-1 du code de l'environnement (Directive 2007/2/CE (INSPIRE), Article 13.1.f)</label>
+        </item>
+        <item>
+          <key>INSPIRE_Directive_Article13_1g</key>
+          <label>L124-4-I-3 du code de l'environnement (Directive 2007/2/CE (INSPIRE), Article 13.1.g)</label>
+        </item>
+        <item>
+          <key>INSPIRE_Directive_Article13_1h</key>
+          <label>L124-4-I-2 du code de l'environnement (Directive 2007/2/CE (INSPIRE), Article 13.1.h)</label>
+        </item>
+      </xsl:with-param>
+    </xsl:call-template>
+  </xsl:variable>
+
+  <!-- INSPIRE ConditionsApplyingToAccessAndUse -->
+  <xsl:variable name="conditions">
+    <xsl:call-template name="build-registry-lookup">
+      <xsl:with-param name="base-uri" select="'http://inspire.ec.europa.eu/metadata-codelist/ConditionsApplyingToAccessAndUse/noConditionsApply'"/>
+      <xsl:with-param name="entries">
+        <item>
+          <key>noConditionsApply</key>
+          <label>aucune condition ne s'applique</label>
+        </item>
+        <item>
+          <key>conditionsUnknown</key>
+          <label>conditions inconnues</label>
+        </item>
+      </xsl:with-param>
+    </xsl:call-template>
+  </xsl:variable>
+
+
+  <!--
+      Templates
+  -->
+
+  <xsl:template match="gmd:MD_LegalConstraints/gmd:otherConstraints">
+    <xsl:variable name="label" select="gco:CharacterString"/>
+    <xsl:variable name="license">
+      <xsl:call-template name="as-constraint-anchor">
+        <xsl:with-param name="lookup-table" select="$licenses"/>
+        <xsl:with-param name="label" select="$label"/>
+      </xsl:call-template>
+    </xsl:variable>
+    <xsl:variable name="limitation">
+      <xsl:call-template name="as-constraint-anchor">
+        <xsl:with-param name="lookup-table" select="$limitations"/>
+        <xsl:with-param name="label" select="$label"/>
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:choose>
+      <xsl:when test="$license != ''">
+        <xsl:copy-of select="$license"/>
+      </xsl:when>
+      <xsl:when test="$limitation != ''">
+        <xsl:copy-of select="$limitation"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy-of select="."/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="as-constraint-anchor">
+    <xsl:param name="lookup-table"/>
+    <xsl:param name="label"/>
+    <xsl:variable name="match">
+      <xsl:call-template name="lookup-label">
+        <xsl:with-param name="lookup-table" select="$lookup-table"/>
+        <xsl:with-param name="label" select="$label"/>
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:if test="$match != ''">
+      <gmd:otherConstraints>
+        <xsl:copy-of select="namespace::*"/>
+        <xsl:copy-of select="@*"/>
+        <gmx:Anchor>
+          <xsl:attribute name="xlink:href">
+            <xsl:value-of select="exsl:node-set($match)/uri"/>
+          </xsl:attribute>
+          <xsl:value-of select="exsl:node-set($match)/label"/>
+        </gmx:Anchor>
+      </gmd:otherConstraints>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+
+  <!--
+      Helpers
+  -->
+
+  <xsl:template name="build-registry-lookup">
+    <xsl:param name="entries"/>
+    <xsl:param name="base-uri"/>
+
+    <xsl:for-each select="exsl:node-set($entries)/item">
+      <xsl:variable name="uri" select="concat($base-uri, '/', key)"/>
+      <item>
+        <alt>
+          <xsl:call-template name="normalize-string">
+            <xsl:with-param name="string" select="key"/>
+          </xsl:call-template>
+        </alt>
+        <alt>
+          <xsl:call-template name="normalize-string">
+            <xsl:with-param name="string" select="$uri"/>
+          </xsl:call-template>
+        </alt>
+        <alt>
+          <xsl:call-template name="normalize-string">
+            <xsl:with-param name="string" select="label"/>
+          </xsl:call-template>
+        </alt>
+        <xsl:for-each select="alt">
+          <alt>
+            <xsl:call-template name="normalize-string">
+              <xsl:with-param name="string" select="."/>
+            </xsl:call-template>
+          </alt>
+        </xsl:for-each>
+        <match>
+          <uri><xsl:value-of select="$uri"/></uri>
+          <xsl:copy-of select="label"/>
+        </match>
+      </item>
+    </xsl:for-each>
+  </xsl:template>
+  
+  <xsl:template name="lookup-label">
+    <xsl:param name="lookup-table"/>
+    <xsl:param name="label"/>
+
+    <!-- full label -->
+    <xsl:variable name="normalized">
+      <xsl:call-template name="normalize-string">
+        <xsl:with-param name="string" select="$label"/>
+      </xsl:call-template>
+    </xsl:variable>
+    <xsl:variable name="match-full">
+      <xsl:copy-of select="exsl:node-set($lookup-table)/item[alt=$normalized]/match/*"/>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="$match-full != ''">
+        <xsl:copy-of select="$match-full"/>
+      </xsl:when>
+      <xsl:otherwise>
+      <!-- all but url -->
+        <xsl:variable name="label-nourl" select="normalize-space(substring-before($normalized, 'http'))"/>
+        <xsl:variable name="match-nourl">
+          <xsl:copy-of select="exsl:node-set($lookup-table)/item[alt=$label-nourl]/match/*"/>
+        </xsl:variable>
+        <xsl:choose>
+          <xsl:when test="$match-nourl != ''">
+            <xsl:copy-of select="$match-nourl"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <!-- url -->
+            <xsl:variable name="label-url" select="concat('http', substring-after($normalized, 'http'))"/>
+            <xsl:variable name="match-url">
+              <xsl:copy-of select="exsl:node-set($lookup-table)/item[alt=$label-url]/match/*"/>
+            </xsl:variable>
+              <xsl:if test="$match-url != ''">
+                <xsl:copy-of select="$match-url"/>
+              </xsl:if>
+            </xsl:otherwise>
+          </xsl:choose>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="normalize-string">
+    <xsl:param name="string"/>
+
+    <xsl:variable name="accents_up">ÀÂÇÉÈÊËÎÏÔÙÛÜ</xsl:variable>
+    <xsl:variable name="accents_lo">àâçéèêëîïôùûü</xsl:variable>
+    <xsl:variable name="accents_tr">aaceeeeiiouuu</xsl:variable>
+
+    <xsl:variable name="tr_from">’</xsl:variable>
+    <xsl:variable name="tr_to"  >'</xsl:variable>
+
+    <xsl:variable name="lowercase">
+      <xsl:value-of select="translate($string,
+                            concat('ABCDEFGHIJKLMNOPQRSTUVWXYZ', $accents_up),
+                            concat('abcdefghijklmnopqrstuvwxyz', $accents_lo))"/>
+    </xsl:variable>
+
+    <xsl:variable name="folded">
+      <xsl:value-of select="translate($lowercase,
+                            concat($accents_lo, $tr_from),
+                            concat($accents_tr, $tr_to))"/>
+    </xsl:variable>
+
+    <!-- normalize-space at the end in case we fold to space -->
+    <xsl:value-of select="normalize-space($folded)"/>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
fix https://github.com/ecolabdata/ecospheres/issues/354 

Lorsque qu'un `gmd:otherConstraints/gco:CharacterString` match dans une des tables de mapping, le `gco:CharacterString` est converti en `gmx:Anchor` pointant vers l'entrée mappée.

Heuristique de match ([code](https://github.com/ecolabdata/ecospheres-xslt/blob/651e8b305362467247cbe33a4d99c5fa6c55d8af/xslts/anchor-resource-constraints.xsl#L254)) : 
- Le texte de `gco:CharacterString` est normalisé (lowecase + ascii folding + trim + normalisation des espaces dans le texte, [code](https://github.com/ecolabdata/ecospheres-xslt/blob/651e8b305362467247cbe33a4d99c5fa6c55d8af/xslts/anchor-resource-constraints.xsl#L296)).
- Si le texte normalisé matche => done
- Sinon, le texte normalisé est séparé en [texte non url] + [url] et chaque partie est matchée indépendament. La séparation est naive : on split sur "http", donc [texte non url] est forcément avant [url].

Tables de mapping ([code](https://github.com/ecolabdata/ecospheres-xslt/blob/651e8b305362467247cbe33a4d99c5fa6c55d8af/xslts/anchor-resource-constraints.xsl#L19])): 
- Licenses (mélange de https://www.data.gouv.fr/api/1/datasets/licenses/ et compléments manuels):
  - etalab-2.0
  - ODbL-1.0
- Registres INSPIRE (traductions du guide CNIG):
  - https://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/ : 
  - https://inspire.ec.europa.eu/metadata-codelist/ConditionsApplyingToAccessAndUse/