### PR TITLE
Set xslt encoding to utf-8

### DIFF
--- a/xslts/anchor-resource-constraints.xsl
+++ b/xslts/anchor-resource-constraints.xsl
@@ -15,6 +15,8 @@ https://ecospheres.gitbook.io/recommandations-iso-dcat/adaptation-des-metadonnee
                 extension-element-prefixes="exsl"
                 exclude-result-prefixes="#all">
 
+  <xsl:output encoding="UTF-8"/>
+
   <!--
       Text-to-anchor mappings
   -->

--- a/xslts/default-record-type.xsl
+++ b/xslts/default-record-type.xsl
@@ -17,6 +17,8 @@ Si `gmd:hierarchyLevel` est absent, la transformation ajoute :
                 xmlns:gco="http://www.isotc211.org/2005/gco"
                 exclude-result-prefixes="#all">
 
+  <xsl:output encoding="UTF-8"/>
+
   <xsl:variable name="elementMissing" select="not(/gmd:MD_Metadata/gmd:hierarchyLevel)"/>
   <xsl:variable name="insertAfter" select="name(/gmd:MD_Metadata/*[name()='gmd:fileIdentifier' or name()='gmd:language'
                                            or name()='gmd:characterSet' or name()='gmd:parentIdentifier'][last()])"/>

--- a/xslts/set-resource-function.xsl
+++ b/xslts/set-resource-function.xsl
@@ -11,6 +11,8 @@ https://ecospheres.gitbook.io/recommandations-iso-dcat/adaptation-des-metadonnee
                 xmlns:gmd="http://www.isotc211.org/2005/gmd"
                 exclude-result-prefixes="#all">
 
+  <xsl:output encoding="UTF-8"/>
+
   <xsl:param name="match-string" required="yes"/>
   <xsl:param name="match-field" select="'name'" required="yes"/>
   <xsl:param name="function-type" select="'download'" required="yes"/>

--- a/xslts/split-resource-constraints.xsl
+++ b/xslts/split-resource-constraints.xsl
@@ -10,6 +10,8 @@ https://ecospheres.gitbook.io/recommandations-iso-dcat/adaptation-des-metadonnee
                 xmlns:gmd="http://www.isotc211.org/2005/gmd"
                 exclude-result-prefixes="#all">
 
+  <xsl:output encoding="UTF-8"/>
+
   <!-- non-ambiguous OC = ACo + UCx + OC + UL? => ACo + OC / UCx + UL? -->
   <xsl:template match="gmd:resourceConstraints[gmd:MD_LegalConstraints[
                          gmd:accessConstraints/gmd:MD_RestrictionCode[@codeListValue = 'otherRestrictions']


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres-isomorphe/issues/73

From https://lxml.de/xpathxslt.html#xslt-result-objects:

> The result is always a plain string, encoded as requested by the
> xsl:output element in the stylesheet. If you want a Python
> Unicode/Text string instead, you should set this encoding to
> UTF-8 (unless the ASCII default is sufficient).