### PR TITLE
fix: reintroduce param check

### DIFF
--- a/xslts/distributions-add-function.xsl
+++ b/xslts/distributions-add-function.xsl
@@ -25,6 +25,10 @@ https://ecospheres.gitbook.io/recommandations-iso-dcat/adaptation-des-metadonnee
   </xsl:variable>
 
   <xsl:template match="gmd:transferOptions/*/gmd:onLine/gmd:CI_OnlineResource">
+    <xsl:if test="$match-string-normalized = ''">
+      <xsl:message terminate="yes">Error: Empty parameter "match-string"</xsl:message>
+    </xsl:if>
+
     <xsl:variable name="function">
       <xsl:choose>
         <xsl:when test="not(gmd:function) or $override-existing = 'yes'">


### PR DESCRIPTION
This isn't needed in XSLT 2.0, but lxml will ignore the "required" parameter attribute, so let's keep that check until we move to a 2.0 processor.