### PR TITLE
Improve split use/access handling

### DIFF
--- a/fixtures/sample--resource-constraints-0AC-1UCo-1OCa-1UL.xml
+++ b/fixtures/sample--resource-constraints-0AC-1UCo-1OCa-1UL.xml
@@ -15,21 +15,14 @@
     <gmd:MD_DataIdentification>
       <gmd:resourceConstraints>
         <gmd:MD_LegalConstraints>
-          <gmd:accessConstraints>
-            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="copyright"/>
-          </gmd:accessConstraints>
-        </gmd:MD_LegalConstraints>
-      </gmd:resourceConstraints>
-      <gmd:resourceConstraints>
-        <gmd:MD_LegalConstraints>
+          <gmd:useLimitation>
+            <gco:CharacterString>limitation 1</gco:CharacterString>
+          </gmd:useLimitation>
           <gmd:useConstraints>
             <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
           </gmd:useConstraints>
           <gmd:otherConstraints>
-            <gco:CharacterString>constraint 1</gco:CharacterString>
-          </gmd:otherConstraints>
-          <gmd:otherConstraints>
-            <gco:CharacterString>constraint 2</gco:CharacterString>
+            <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">Pas de restriction d'accès public</gmx:Anchor>
           </gmd:otherConstraints>
         </gmd:MD_LegalConstraints>
       </gmd:resourceConstraints>

--- a/fixtures/sample--resource-constraints-1ACx-1UCo-1OCa-1UL.xml
+++ b/fixtures/sample--resource-constraints-1ACx-1UCo-1OCa-1UL.xml
@@ -15,21 +15,17 @@
     <gmd:MD_DataIdentification>
       <gmd:resourceConstraints>
         <gmd:MD_LegalConstraints>
+          <gmd:useLimitation>
+            <gco:CharacterString>limitation 1</gco:CharacterString>
+          </gmd:useLimitation>
           <gmd:accessConstraints>
             <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="copyright"/>
           </gmd:accessConstraints>
-        </gmd:MD_LegalConstraints>
-      </gmd:resourceConstraints>
-      <gmd:resourceConstraints>
-        <gmd:MD_LegalConstraints>
           <gmd:useConstraints>
             <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
           </gmd:useConstraints>
           <gmd:otherConstraints>
-            <gco:CharacterString>constraint 1</gco:CharacterString>
-          </gmd:otherConstraints>
-          <gmd:otherConstraints>
-            <gco:CharacterString>constraint 2</gco:CharacterString>
+            <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">Pas de restriction d'accès public</gmx:Anchor>
           </gmd:otherConstraints>
         </gmd:MD_LegalConstraints>
       </gmd:resourceConstraints>

--- a/tests/constraints-split-use-access.sample--resource-constraints-0AC-1UCo-1OCa-1UL.msg
+++ b/tests/constraints-split-use-access.sample--resource-constraints-0AC-1UCo-1OCa-1UL.msg
@@ -1,0 +1,1 @@
+'otherConstraints' -> 'accessConstraints', car 'Anchor'="LimitationsOnPublicAccess".

--- a/tests/constraints-split-use-access.sample--resource-constraints-0AC-1UCo-1OCa-1UL.xml
+++ b/tests/constraints-split-use-access.sample--resource-constraints-0AC-1UCo-1OCa-1UL.xml
@@ -16,21 +16,21 @@
       <gmd:resourceConstraints>
         <gmd:MD_LegalConstraints>
           <gmd:accessConstraints>
-            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="copyright"/>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
           </gmd:accessConstraints>
+          <gmd:otherConstraints>
+            <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">Pas de restriction d'accès public</gmx:Anchor>
+          </gmd:otherConstraints>
         </gmd:MD_LegalConstraints>
       </gmd:resourceConstraints>
       <gmd:resourceConstraints>
         <gmd:MD_LegalConstraints>
+          <gmd:useLimitation>
+            <gco:CharacterString>limitation 1</gco:CharacterString>
+          </gmd:useLimitation>
           <gmd:useConstraints>
             <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
           </gmd:useConstraints>
-          <gmd:otherConstraints>
-            <gco:CharacterString>constraint 1</gco:CharacterString>
-          </gmd:otherConstraints>
-          <gmd:otherConstraints>
-            <gco:CharacterString>constraint 2</gco:CharacterString>
-          </gmd:otherConstraints>
         </gmd:MD_LegalConstraints>
       </gmd:resourceConstraints>
     </gmd:MD_DataIdentification>

--- a/tests/constraints-split-use-access.sample--resource-constraints-1ACo-1UCo-1OC-0UL.msg
+++ b/tests/constraints-split-use-access.sample--resource-constraints-1ACo-1UCo-1OC-0UL.msg
@@ -1,0 +1,1 @@
+[isomorphe:check] 'otherConstraints' ambigu.

--- a/tests/constraints-split-use-access.sample--resource-constraints-1ACo-1UCo-1OC-1UL.msg
+++ b/tests/constraints-split-use-access.sample--resource-constraints-1ACo-1UCo-1OC-1UL.msg
@@ -1,0 +1,1 @@
+[isomorphe:check] 'otherConstraints' -> 'accessConstraints', car présence de 'useLimitation'.

--- a/tests/constraints-split-use-access.sample--resource-constraints-1ACo-1UCo-1OC-2UL.msg
+++ b/tests/constraints-split-use-access.sample--resource-constraints-1ACo-1UCo-1OC-2UL.msg
@@ -1,0 +1,1 @@
+[isomorphe:check] 'otherConstraints' -> 'accessConstraints', car présence de 'useLimitation'.

--- a/tests/constraints-split-use-access.sample--resource-constraints-1ACo-1UCo-2OC-0UL.msg
+++ b/tests/constraints-split-use-access.sample--resource-constraints-1ACo-1UCo-2OC-0UL.msg
@@ -1,0 +1,1 @@
+[isomorphe:check] 'otherConstraints' ambigu.

--- a/tests/constraints-split-use-access.sample--resource-constraints-1ACo-1UCo-2OC-1UL.msg
+++ b/tests/constraints-split-use-access.sample--resource-constraints-1ACo-1UCo-2OC-1UL.msg
@@ -1,0 +1,1 @@
+[isomorphe:check] 'otherConstraints' ambigu.

--- a/tests/constraints-split-use-access.sample--resource-constraints-1ACx-1UCo-1OC-0UL.msg
+++ b/tests/constraints-split-use-access.sample--resource-constraints-1ACx-1UCo-1OC-0UL.msg
@@ -1,0 +1,1 @@
+[isomorphe:check] 'otherConstraints' -> 'useConstraints', mais souvent problématique.

--- a/tests/constraints-split-use-access.sample--resource-constraints-1ACx-1UCo-1OC-0UL.xml
+++ b/tests/constraints-split-use-access.sample--resource-constraints-1ACx-1UCo-1OC-0UL.xml
@@ -18,6 +18,10 @@
           <gmd:accessConstraints>
             <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="copyright"/>
           </gmd:accessConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
           <gmd:useConstraints>
             <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
           </gmd:useConstraints>

--- a/tests/constraints-split-use-access.sample--resource-constraints-1ACx-1UCo-1OC-1UL.msg
+++ b/tests/constraints-split-use-access.sample--resource-constraints-1ACx-1UCo-1OC-1UL.msg
@@ -1,0 +1,1 @@
+[isomorphe:check] 'otherConstraints' -> 'useConstraints', mais souvent problématique.

--- a/tests/constraints-split-use-access.sample--resource-constraints-1ACx-1UCo-1OC-1UL.xml
+++ b/tests/constraints-split-use-access.sample--resource-constraints-1ACx-1UCo-1OC-1UL.xml
@@ -15,12 +15,16 @@
     <gmd:MD_DataIdentification>
       <gmd:resourceConstraints>
         <gmd:MD_LegalConstraints>
-          <gmd:useLimitation>
-            <gco:CharacterString>limitation 1</gco:CharacterString>
-          </gmd:useLimitation>
           <gmd:accessConstraints>
             <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="copyright"/>
           </gmd:accessConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useLimitation>
+            <gco:CharacterString>limitation 1</gco:CharacterString>
+          </gmd:useLimitation>
           <gmd:useConstraints>
             <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
           </gmd:useConstraints>

--- a/tests/constraints-split-use-access.sample--resource-constraints-1ACx-1UCo-1OCa-1UL.msg
+++ b/tests/constraints-split-use-access.sample--resource-constraints-1ACx-1UCo-1OCa-1UL.msg
@@ -1,0 +1,1 @@
+'otherConstraints' -> 'accessConstraints', car 'Anchor'="LimitationsOnPublicAccess".

--- a/tests/constraints-split-use-access.sample--resource-constraints-1ACx-1UCo-1OCa-1UL.xml
+++ b/tests/constraints-split-use-access.sample--resource-constraints-1ACx-1UCo-1OCa-1UL.xml
@@ -18,19 +18,19 @@
           <gmd:accessConstraints>
             <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="copyright"/>
           </gmd:accessConstraints>
+          <gmd:otherConstraints>
+            <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">Pas de restriction d'accès public</gmx:Anchor>
+          </gmd:otherConstraints>
         </gmd:MD_LegalConstraints>
       </gmd:resourceConstraints>
       <gmd:resourceConstraints>
         <gmd:MD_LegalConstraints>
+          <gmd:useLimitation>
+            <gco:CharacterString>limitation 1</gco:CharacterString>
+          </gmd:useLimitation>
           <gmd:useConstraints>
             <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
           </gmd:useConstraints>
-          <gmd:otherConstraints>
-            <gco:CharacterString>constraint 1</gco:CharacterString>
-          </gmd:otherConstraints>
-          <gmd:otherConstraints>
-            <gco:CharacterString>constraint 2</gco:CharacterString>
-          </gmd:otherConstraints>
         </gmd:MD_LegalConstraints>
       </gmd:resourceConstraints>
     </gmd:MD_DataIdentification>

--- a/tests/constraints-split-use-access.sample--resource-constraints-1ACx-1UCo-2OC-0UL.msg
+++ b/tests/constraints-split-use-access.sample--resource-constraints-1ACx-1UCo-2OC-0UL.msg
@@ -1,0 +1,1 @@
+[isomorphe:check] 'otherConstraints' -> 'useConstraints', mais souvent problématique.

--- a/tests/constraints-split-use-access.sample--resource-constraints-1ACx-1UCx-1OC-0UL.msg
+++ b/tests/constraints-split-use-access.sample--resource-constraints-1ACx-1UCx-1OC-0UL.msg
@@ -1,0 +1,1 @@
+[isomorphe:check] 'otherConstraints' ambigu. 

--- a/tests/constraints-split-use-access.sample--resource-constraints-1ACx-1UCx-1OC-1UL.msg
+++ b/tests/constraints-split-use-access.sample--resource-constraints-1ACx-1UCx-1OC-1UL.msg
@@ -1,0 +1,1 @@
+[isomorphe:check] 'otherConstraints' -> 'accessConstraints', car présence de 'useLimitation'.

--- a/tests/constraints-split-use-access.sample--resource-constraints-1ACx-1UCx-2OC-0UL.msg
+++ b/tests/constraints-split-use-access.sample--resource-constraints-1ACx-1UCx-2OC-0UL.msg
@@ -1,0 +1,1 @@
+[isomorphe:check] 'otherConstraints' ambigu.

--- a/tests/constraints-split-use-access.sample--resource-constraints-2ACo-2UCo-1OC-1UL.msg
+++ b/tests/constraints-split-use-access.sample--resource-constraints-2ACo-2UCo-1OC-1UL.msg
@@ -1,0 +1,1 @@
+[isomorphe:check] 'otherConstraints' -> 'accessConstraints', car présence de 'useLimitation'.

--- a/tests/constraints-split-use-access.sample--resource-constraints-2ACo-2UCx-1OC-1UL.msg
+++ b/tests/constraints-split-use-access.sample--resource-constraints-2ACo-2UCx-1OC-1UL.msg
@@ -1,0 +1,1 @@
+[isomorphe:check] 'otherConstraints' -> 'accessConstraints', car présence de 'useLimitation'.

--- a/xslts/constraints-split-use-access.md
+++ b/xslts/constraints-split-use-access.md
@@ -8,6 +8,11 @@ Sépare les conditions d'utilisation des conditions d'accès.
 Aucun.
 
 
+## Prérequis
+
+- <a href="constraints-convert-to-anchor">`constraints-convert-to-anchor`</a> (recommandé).
+
+
 ## Motivation
 
 Lorsqu'un élément `gmd:resourceConstraints` contient à la fois un élément `gmd:accessConstraints` et un élément `gmd:useConstraints`, tous les éléments `gmd:otherConstraints` également présents vont être doublonnés en condition d'utilisation *et* en condition d'accès par le convertisseur SEMICeu ISO-19139 vers GeoDCAT-AP.

--- a/xslts/constraints-split-use-access.xsl
+++ b/xslts/constraints-split-use-access.xsl
@@ -5,13 +5,54 @@
 
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
                 xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
                 exclude-result-prefixes="#all">
 
   <xsl:output encoding="UTF-8"/>
 
-  <!-- non-ambiguous OC = ACo + UCx + OC + UL? => ACo + OC / UCx + UL? -->
-  <xsl:template match="gmd:resourceConstraints[gmd:MD_LegalConstraints[
+  <!-- Non-ambiguous OC: AC? + UC + OC[Anchor=LimitationsOnPublicAccess] + UL? => AC? + OC / UC + UL? -->
+  <xsl:template priority="4"
+                match="gmd:resourceConstraints[gmd:MD_LegalConstraints[
+                         gmd:useConstraints
+                         and gmd:otherConstraints
+                         and count(gmd:otherConstraints) =
+                           count(gmd:otherConstraints[gmx:Anchor[@xlink:href[
+                             starts-with(., 'http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess')
+                           ]]])
+                       ]]">
+    <xsl:message>'otherConstraints' -> 'accessConstraints', car 'Anchor'="LimitationsOnPublicAccess".</xsl:message>
+    <!-- access constraints -->
+    <xsl:call-template name="add-resource-constraint">
+      <xsl:with-param name="constraints">
+        <xsl:choose>
+          <xsl:when test="gmd:MD_LegalConstraints/gmd:accessConstraints">
+            <xsl:copy-of select="gmd:MD_LegalConstraints/gmd:accessConstraints"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <!-- create if missing -->
+            <gmd:accessConstraints>
+              <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+            </gmd:accessConstraints>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:copy-of select="gmd:MD_LegalConstraints/gmd:otherConstraints"/>
+      </xsl:with-param>
+    </xsl:call-template>
+    <!-- use constraints -->
+    <xsl:call-template name="add-resource-constraint">
+      <xsl:with-param name="constraints">
+        <xsl:copy-of select="gmd:MD_LegalConstraints/gmd:useLimitation"/>
+        <xsl:copy-of select="gmd:MD_LegalConstraints/gmd:useConstraints"/>
+      </xsl:with-param>
+    </xsl:call-template>
+  </xsl:template>
+
+  <!-- Non-ambiguous OC: ACo + UCx + OC + UL? => ACo + OC / UCx + UL? -->
+  <xsl:template priority="3"
+                match="gmd:resourceConstraints[gmd:MD_LegalConstraints[
                          gmd:accessConstraints/gmd:MD_RestrictionCode[@codeListValue = 'otherRestrictions']
                          and (gmd:useConstraints and
                               not(gmd:useConstraints/gmd:MD_RestrictionCode[@codeListValue = 'otherRestrictions']))
@@ -33,11 +74,33 @@
     </xsl:call-template>
   </xsl:template>
 
-  <!-- non-ambiguous OC = ACx + UCo + OC + UL? => noop -->
-  <!-- no mapping for now, too many misclassifications -->
+  <!-- Non-ambiguous OC: ACx + UCo + OC + UL? => ACx / UCo + OC + UL? -->
+  <xsl:template priority="3"
+                match="gmd:resourceConstraints[gmd:MD_LegalConstraints[
+                         gmd:accessConstraints/gmd:MD_RestrictionCode[@codeListValue != 'otherRestrictions']
+                         and gmd:useConstraints/gmd:MD_RestrictionCode[@codeListValue = 'otherRestrictions']
+                         and gmd:otherConstraints
+                       ]]">
+    <xsl:message>[isomorphe:check] 'otherConstraints' -> 'useConstraints', mais souvent problématique.</xsl:message>
+    <!-- access constraints -->
+    <xsl:call-template name="add-resource-constraint">
+      <xsl:with-param name="constraints">
+        <xsl:copy-of select="gmd:MD_LegalConstraints/gmd:accessConstraints"/>
+      </xsl:with-param>
+    </xsl:call-template>
+    <!-- use constraints -->
+    <xsl:call-template name="add-resource-constraint">
+      <xsl:with-param name="constraints">
+        <xsl:copy-of select="gmd:MD_LegalConstraints/gmd:useLimitation"/>
+        <xsl:copy-of select="gmd:MD_LegalConstraints/gmd:useConstraints"/>
+        <xsl:copy-of select="gmd:MD_LegalConstraints/gmd:otherConstraints"/>
+      </xsl:with-param>
+    </xsl:call-template>
+  </xsl:template>
 
-  <!-- special case of ambiguous OC = (ACo + UCo + 1OC + UL) | (ACx + UCx + 1OC + UL) => AC + OC / UC + UL -->
-  <xsl:template match="gmd:resourceConstraints[gmd:MD_LegalConstraints[
+  <!-- Special case of ambiguous OC: (ACo + UCo + 1OC + UL) | (ACx + UCx + 1OC + UL) => AC + OC / UC + UL -->
+  <xsl:template priority="3"
+                match="gmd:resourceConstraints[gmd:MD_LegalConstraints[
                          (
                            (gmd:accessConstraints/gmd:MD_RestrictionCode[@codeListValue != 'otherRestrictions']
                             and (gmd:useConstraints[not(gmd:MD_RestrictionCode)]
@@ -49,6 +112,7 @@
                          and count(gmd:otherConstraints) = 1
                          and gmd:useLimitation
                        ]]">
+    <xsl:message>[isomorphe:check] 'otherConstraints' -> 'accessConstraints', car présence de 'useLimitation'.</xsl:message>
     <!-- access constraints -->
     <xsl:call-template name="add-resource-constraint">
       <xsl:with-param name="constraints">
@@ -63,6 +127,18 @@
         <xsl:copy-of select="gmd:MD_LegalConstraints/gmd:useConstraints"/>
       </xsl:with-param>
     </xsl:call-template>
+  </xsl:template>
+
+  <xsl:template priority="2"
+                match="gmd:resourceConstraints[gmd:MD_LegalConstraints[
+                         gmd:accessConstraints
+                         and gmd:useConstraints
+                         and gmd:otherConstraints
+                       ]]">
+    <xsl:message>[isomorphe:check] 'otherConstraints' ambigu.</xsl:message>
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
   </xsl:template>
 
   <xsl:template name="add-resource-constraint">


### PR DESCRIPTION
Gère les cas particuliers suivants : 

- > 'otherConstraints' -> 'accessConstraints', car 'Anchor'="LimitationsOnPublicAccess".
  
  Nécessite de passer `constraints-convert-to-anchor.xsl` en amont.

- > [isomorphe:check] 'otherConstraints' -> 'accessConstraints', car présence de 'useLimitation'.
  
  Cas déjà traité dans le XSLT mais désormais identifié [isomorphe:check] car il y a des faux positifs.

- > [isomorphe:check] 'otherConstraints' -> 'useConstraints', mais souvent problématique.
  
  Cas "ACx + UCo + OC + UL?" souvent mal géré d'après nos stats sur catalogues tests.

- > [isomorphe:check] 'otherConstraints' ambigu.
  
  Tous les cas ambigus (non encore) couverts.

Les cas "[isomorphe:check]" sont identifiés par ISOmorphe via https://github.com/ecolabdata/ecospheres-isomorphe/pull/131.