### PR TITLE
fix: Invert "match-string" and "match-url" parameters

### DIFF
--- a/tests/distributions-add-function.datara--89d278a5-ef6a-45a9-9ced-2b348a9963bb.atom-name.conf
+++ b/tests/distributions-add-function.datara--89d278a5-ef6a-45a9-9ced-2b348a9963bb.atom-name.conf
@@ -1,4 +1,4 @@
 [params]
-match-string = "acces au lien atom de telechargement"
 match-field = "name"
+match-string = "acces au lien atom de telechargement"
 override-existing = "no"

--- a/tests/distributions-add-function.datara--89d278a5-ef6a-45a9-9ced-2b348a9963bb.atom-url.conf
+++ b/tests/distributions-add-function.datara--89d278a5-ef6a-45a9-9ced-2b348a9963bb.atom-url.conf
@@ -1,4 +1,4 @@
 [params]
-match-string = "/rss/atomfeed/atomdataset"
 match-field = "url"
+match-string = "/rss/atomfeed/atomdataset"
 override-existing = "no"

--- a/tests/distributions-add-function.datara--89d278a5-ef6a-45a9-9ced-2b348a9963bb.download-name.conf
+++ b/tests/distributions-add-function.datara--89d278a5-ef6a-45a9-9ced-2b348a9963bb.download-name.conf
@@ -1,4 +1,4 @@
 [params]
-match-string = "Accès au téléchargement des données"
 match-field = "name"
+match-string = "Accès au téléchargement des données"
 override-existing = "no"

--- a/tests/distributions-add-function.datara--89d278a5-ef6a-45a9-9ced-2b348a9963bb.download-url.conf
+++ b/tests/distributions-add-function.datara--89d278a5-ef6a-45a9-9ced-2b348a9963bb.download-url.conf
@@ -1,4 +1,4 @@
 [params]
-match-string = "/panierDownloadFrontalParametrage?"
 match-field = "url"
+match-string = "/panierDownloadFrontalParametrage?"
 override-existing = "no"

--- a/tests/distributions-add-function.sample--resource-existing-function.no-match.conf
+++ b/tests/distributions-add-function.sample--resource-existing-function.no-match.conf
@@ -1,4 +1,4 @@
 [params]
-match-string = "not matching"
 match-field = "name"
+match-string = "not matching"
 override-existing = "yes"

--- a/tests/distributions-add-function.sample--resource-existing-function.override-no.conf
+++ b/tests/distributions-add-function.sample--resource-existing-function.override-no.conf
@@ -1,4 +1,4 @@
 [params]
-match-string = "WFS GetCapabilities request"
 match-field = "name"
+match-string = "WFS GetCapabilities request"
 override-existing = "no"

--- a/tests/distributions-add-function.sample--resource-existing-function.override-yes.conf
+++ b/tests/distributions-add-function.sample--resource-existing-function.override-yes.conf
@@ -1,4 +1,4 @@
 [params]
-match-string = "WFS GetCapabilities request"
 match-field = "name"
+match-string = "WFS GetCapabilities request"
 override-existing = "yes"

--- a/tests/distributions-add-function.sample--resource-no-function.err
+++ b/tests/distributions-add-function.sample--resource-no-function.err
@@ -1,1 +1,1 @@
-Error: Empty parameter "match-string"
+Error: Empty parameter "match-field"

--- a/tests/distributions-add-function.sample--resource-no-function.function-type.conf
+++ b/tests/distributions-add-function.sample--resource-no-function.function-type.conf
@@ -1,4 +1,4 @@
 [params]
-match-string = "WFS GetCapabilities request"
 match-field = "name"
+match-string = "WFS GetCapabilities request"
 function-type = "order"

--- a/tests/distributions-add-function.sample--resource-no-function.match-field-empty.conf
+++ b/tests/distributions-add-function.sample--resource-no-function.match-field-empty.conf
@@ -1,0 +1,3 @@
+[params]
+match-field = ""
+match-string = "WFS GetCapabilities request"

--- a/tests/distributions-add-function.sample--resource-no-function.match-field-empty.err
+++ b/tests/distributions-add-function.sample--resource-no-function.match-field-empty.err
@@ -1,0 +1,1 @@
+Error: Empty parameter "match-field"

--- a/tests/distributions-add-function.sample--resource-no-function.match-field-invalid.conf
+++ b/tests/distributions-add-function.sample--resource-no-function.match-field-invalid.conf
@@ -1,3 +1,3 @@
 [params]
-match-string = "WFS GetCapabilities request"
 match-field = "foo"
+match-string = "WFS GetCapabilities request"

--- a/tests/distributions-add-function.sample--resource-no-function.match-field-url.conf
+++ b/tests/distributions-add-function.sample--resource-no-function.match-field-url.conf
@@ -1,3 +1,3 @@
 [params]
-match-string = "&REQUEST=GetCapabilities"
 match-field = "url"
+match-string = "&REQUEST=GetCapabilities"

--- a/tests/distributions-add-function.sample--resource-no-function.match-string-empty.conf
+++ b/tests/distributions-add-function.sample--resource-no-function.match-string-empty.conf
@@ -1,2 +1,3 @@
 [params]
+match-field = "name"
 match-string = "   "

--- a/tests/distributions-add-function.sample--resource-no-function.no-match.conf
+++ b/tests/distributions-add-function.sample--resource-no-function.no-match.conf
@@ -1,3 +1,3 @@
 [params]
-match-string = "not matching"
 match-field = "name"
+match-string = "not matching"

--- a/tests/distributions-add-function.sample--resource-no-function.no-params.err
+++ b/tests/distributions-add-function.sample--resource-no-function.no-params.err
@@ -1,1 +1,1 @@
-Error: Empty parameter "match-string"
+Error: Empty parameter "match-field"

--- a/tests/distributions-add-function.sample--resource-no-function.override-no.conf
+++ b/tests/distributions-add-function.sample--resource-no-function.override-no.conf
@@ -1,4 +1,4 @@
 [params]
-match-string = "WFS GetCapabilities request"
 match-field = "name"
+match-string = "WFS GetCapabilities request"
 override-existing = "no"

--- a/tests/distributions-add-function.sample--resource-no-function.override-yes.conf
+++ b/tests/distributions-add-function.sample--resource-no-function.override-yes.conf
@@ -1,4 +1,4 @@
 [params]
-match-string = "WFS GetCapabilities request"
 match-field = "name"
+match-string = "WFS GetCapabilities request"
 override-existing = "yes"

--- a/tests/distributions-add-function.sample--resource-special-chars.match-string-accent.conf
+++ b/tests/distributions-add-function.sample--resource-special-chars.match-string-accent.conf
@@ -1,3 +1,3 @@
 [params]
-match-string = "documents associes"
 match-field = "name"
+match-string = "documents associes"

--- a/tests/distributions-add-function.sample--resource-special-chars.match-string-paren.conf
+++ b/tests/distributions-add-function.sample--resource-special-chars.match-string-paren.conf
@@ -1,3 +1,3 @@
 [params]
-match-string = "(Atom)"
 match-field = "name"
+match-string = "(Atom)"

--- a/tests/distributions-add-function.sample--resource-special-chars.match-string-quote.conf
+++ b/tests/distributions-add-function.sample--resource-special-chars.match-string-quote.conf
@@ -1,3 +1,3 @@
 [params]
-match-string = "l'internet"
 match-field = "name"
+match-string = "l'internet"

--- a/xslts/distributions-add-function.md
+++ b/xslts/distributions-add-function.md
@@ -9,7 +9,7 @@ Ajoute un élément de type `gmd:function` à une distribution.
 
 | Paramètre           | Requis | Défaut     | Description |
 |:--------------------|:-------|:-----------|:------------|
-| `match-field`       | oui    | "name"     | Champ dans lequel rechercher `match-string`, parmi : <ul><li>"name" : Recherche dans `gmd:name/gco:CharacterString`.</li><li>"url" : Recherche dans `gmd:linkage/gmd:URL`.</li></ul> |
+| `match-field`       | oui    | \<aucun>   | Champ dans lequel rechercher `match-string`, parmi : <ul><li>"name" : Recherche dans `gmd:name/gco:CharacterString`.</li><li>"url" : Recherche dans `gmd:linkage/gmd:URL`.</li></ul> |
 | `match-string`      | oui    | \<aucun>   | Chaîne de caractères à rechercher dans `match-field`. |
 | `function-type`     | oui    | "download" | Type de `gmd:function` à ajouter à la distribution, parmi "download", "offlineAccess", "order". |
 | `override-existing` | oui    | "no"       | Si "no", seules les distributions ne contenant pas de `gmd:function` sont prises en compte.<br/>Si "yes", les distributions contenant déjà un `gmd:function` sont également prises en compte, et un `gmd:function` existant sera remplacé. |

--- a/xslts/distributions-add-function.md
+++ b/xslts/distributions-add-function.md
@@ -9,8 +9,8 @@ Ajoute un élément de type `gmd:function` à une distribution.
 
 | Paramètre           | Requis | Défaut     | Description |
 |:--------------------|:-------|:-----------|:------------|
-| `match-string`      | oui    | \<aucun>   | Chaîne de caractères à rechercher dans `match-field`. |
 | `match-field`       | oui    | "name"     | Champ dans lequel rechercher `match-string`, parmi : <ul><li>"name" : Recherche dans `gmd:name/gco:CharacterString`.</li><li>"url" : Recherche dans `gmd:linkage/gmd:URL`.</li></ul> |
+| `match-string`      | oui    | \<aucun>   | Chaîne de caractères à rechercher dans `match-field`. |
 | `function-type`     | oui    | "download" | Type de `gmd:function` à ajouter à la distribution, parmi "download", "offlineAccess", "order". |
 | `override-existing` | oui    | "no"       | Si "no", seules les distributions ne contenant pas de `gmd:function` sont prises en compte.<br/>Si "yes", les distributions contenant déjà un `gmd:function` sont également prises en compte, et un `gmd:function` existant sera remplacé. |
 

--- a/xslts/distributions-add-function.xsl
+++ b/xslts/distributions-add-function.xsl
@@ -11,8 +11,8 @@
 
   <xsl:output encoding="UTF-8"/>
 
-  <xsl:param name="match-string" required="yes"/>
   <xsl:param name="match-field" select="'name'" required="yes"/>
+  <xsl:param name="match-string" required="yes"/>
   <xsl:param name="function-type" select="'download'" required="yes"/>
   <xsl:param name="override-existing" select="'no'" required="yes"/>
 

--- a/xslts/distributions-add-function.xsl
+++ b/xslts/distributions-add-function.xsl
@@ -11,7 +11,7 @@
 
   <xsl:output encoding="UTF-8"/>
 
-  <xsl:param name="match-field" select="'name'" required="yes"/>
+  <xsl:param name="match-field" required="yes"/>
   <xsl:param name="match-string" required="yes"/>
   <xsl:param name="function-type" select="'download'" required="yes"/>
   <xsl:param name="override-existing" select="'no'" required="yes"/>
@@ -23,6 +23,9 @@
   </xsl:variable>
 
   <xsl:template match="gmd:transferOptions/*/gmd:onLine/gmd:CI_OnlineResource">
+    <xsl:if test="$match-field = ''">
+      <xsl:message terminate="yes">Error: Empty parameter "match-field"</xsl:message>
+    </xsl:if>
     <xsl:if test="$match-string-normalized = ''">
       <xsl:message terminate="yes">Error: Empty parameter "match-string"</xsl:message>
     </xsl:if>


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres-xslt/issues/23

Changes : 
- Swap field order in the params list.
- Remove default value for `match-field` in order to force explicit selection. Makes more sense given the new param order (see .md) + there's no field that's a "better" default than another anyway.
- Update param order in all test configs to stay consistent.