### PR TITLE
fix: License anchor mappings

### DIFF
--- a/tests/contraintes-legales-conversion-anchor.sample--resource-constraints-inspire-license-spaces.xml
+++ b/tests/contraintes-legales-conversion-anchor.sample--resource-constraints-inspire-license-spaces.xml
@@ -19,7 +19,7 @@
             <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
           </gmd:useConstraints>
           <gmd:otherConstraints>
-            <gmx:Anchor xlink:href="https://spdx.org/licenses/etalab-2.0">Licence Ouverte / Open Licence version 2.0</gmx:Anchor>
+            <gmx:Anchor xlink:href="http://spdx.org/licenses/etalab-2.0">Licence Ouverte / Open Licence version 2.0</gmx:Anchor>
           </gmd:otherConstraints>
         </gmd:MD_LegalConstraints>
       </gmd:resourceConstraints>

--- a/tests/contraintes-legales-conversion-anchor.sample--resource-constraints-license-key.xml
+++ b/tests/contraintes-legales-conversion-anchor.sample--resource-constraints-license-key.xml
@@ -19,7 +19,7 @@
             <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
           </gmd:useConstraints>
           <gmd:otherConstraints>
-            <gmx:Anchor xlink:href="https://spdx.org/licenses/etalab-2.0">Licence Ouverte / Open Licence version 2.0</gmx:Anchor>
+            <gmx:Anchor xlink:href="http://spdx.org/licenses/etalab-2.0">Licence Ouverte / Open Licence version 2.0</gmx:Anchor>
           </gmd:otherConstraints>
         </gmd:MD_LegalConstraints>
       </gmd:resourceConstraints>

--- a/tests/contraintes-legales-conversion-anchor.sample--resource-constraints-license-label-and-url.xml
+++ b/tests/contraintes-legales-conversion-anchor.sample--resource-constraints-license-label-and-url.xml
@@ -19,7 +19,7 @@
             <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
           </gmd:useConstraints>
           <gmd:otherConstraints>
-            <gmx:Anchor xlink:href="https://spdx.org/licenses/etalab-2.0">Licence Ouverte / Open Licence version 2.0</gmx:Anchor>
+            <gmx:Anchor xlink:href="http://spdx.org/licenses/etalab-2.0">Licence Ouverte / Open Licence version 2.0</gmx:Anchor>
           </gmd:otherConstraints>
         </gmd:MD_LegalConstraints>
       </gmd:resourceConstraints>

--- a/tests/contraintes-legales-conversion-anchor.sample--resource-constraints-license-label.xml
+++ b/tests/contraintes-legales-conversion-anchor.sample--resource-constraints-license-label.xml
@@ -19,7 +19,7 @@
             <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
           </gmd:useConstraints>
           <gmd:otherConstraints>
-            <gmx:Anchor xlink:href="https://spdx.org/licenses/etalab-2.0">Licence Ouverte / Open Licence version 2.0</gmx:Anchor>
+            <gmx:Anchor xlink:href="http://spdx.org/licenses/etalab-2.0">Licence Ouverte / Open Licence version 2.0</gmx:Anchor>
           </gmd:otherConstraints>
         </gmd:MD_LegalConstraints>
       </gmd:resourceConstraints>

--- a/tests/contraintes-legales-conversion-anchor.sample--resource-constraints-license-url.xml
+++ b/tests/contraintes-legales-conversion-anchor.sample--resource-constraints-license-url.xml
@@ -19,7 +19,7 @@
             <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
           </gmd:useConstraints>
           <gmd:otherConstraints>
-            <gmx:Anchor xlink:href="https://spdx.org/licenses/etalab-2.0">Licence Ouverte / Open Licence version 2.0</gmx:Anchor>
+            <gmx:Anchor xlink:href="http://spdx.org/licenses/etalab-2.0">Licence Ouverte / Open Licence version 2.0</gmx:Anchor>
           </gmd:otherConstraints>
         </gmd:MD_LegalConstraints>
       </gmd:resourceConstraints>

--- a/xslts/contraintes-legales-conversion-anchor.xsl
+++ b/xslts/contraintes-legales-conversion-anchor.xsl
@@ -22,7 +22,7 @@
   <!-- Licenses -->
   <xsl:variable name="licenses">
     <xsl:call-template name="build-registry-lookup">
-      <xsl:with-param name="base-uri" select="'https://spdx.org/licenses'"/>
+      <xsl:with-param name="base-uri" select="'http://spdx.org/licenses'"/>
       <xsl:with-param name="entries">
         <!--
             Partly generated from:

--- a/xslts/contraintes-legales-conversion-anchor.xsl
+++ b/xslts/contraintes-legales-conversion-anchor.xsl
@@ -32,23 +32,47 @@
         <item>
           <key>etalab-2.0</key>
           <label>Licence Ouverte / Open Licence version 2.0</label>
-          <alt>Licence Ouverte (Etalab)</alt>
+          <alt>Licence Ouverte / Open License version 2.0</alt>
           <alt>Licence Ouverte / Open Licence v2.0</alt>
+          <alt>Licence Ouverte / Open License v2.0</alt>
           <alt>Licence Ouverte / Open Licence v2</alt>
+          <alt>Licence Ouverte / Open License v2</alt>
           <alt>Licence Ouverte / Open Licence version 2.0</alt>
-          <alt>Licence Ouverte / Open Licence version 2.0</alt>
+          <alt>Licence Ouverte / Open License version 2.0</alt>
+          <alt>Licence Ouverte / Open Licence version 2</alt>
+          <alt>Licence Ouverte / Open License version 2</alt>
           <alt>Licence Ouverte v2.0 (Etalab)</alt>
+          <alt>License Ouverte v2.0 (Etalab)</alt>
           <alt>Licence Ouverte v2.0</alt>
+          <alt>License Ouverte v2.0</alt>
           <alt>Licence Ouverte v2</alt>
+          <alt>License Ouverte v2</alt>
           <alt>Licence Ouverte version 2.0</alt>
-          <alt>License Etalab v2.0</alt>
-          <alt>License Etalab v2</alt>
-          <alt>License Etalab version 2.0</alt>
-          <alt>License Etalab</alt>
+          <alt>License Ouverte version 2.0</alt>
+          <alt>Licence Ouverte version 2</alt>
+          <alt>License Ouverte version 2</alt>
+          <alt>Licence Ouverte (Etalab)</alt>
+          <alt>License Ouverte (Etalab)</alt>
+          <alt>Licence Ouverte</alt>
           <alt>License Ouverte</alt>
+          <alt>Licence Etalab v2.0</alt>
+          <alt>License Etalab v2.0</alt>
+          <alt>Licence Etalab v2</alt>
+          <alt>License Etalab v2</alt>
+          <alt>Licence Etalab version 2.0</alt>
+          <alt>License Etalab version 2.0</alt>
+          <alt>Licence Etalab version 2</alt>
+          <alt>License Etalab version 2</alt>
+          <alt>Licence Etalab</alt>
+          <alt>License Etalab</alt>
           <alt>Open Licence v2.0</alt>
+          <alt>Open License v2.0</alt>
           <alt>Open Licence v2</alt>
+          <alt>Open License v2</alt>
           <alt>Open Licence version 2.0</alt>
+          <alt>Open License version 2.0</alt>
+          <alt>Open Licence version 2</alt>
+          <alt>Open License version 2</alt>
           <alt>https://github.com/DISIC/politique-de-contribution-open-source/blob/master/LICENSE.pdf</alt>
           <alt>https://github.com/etalab/Licence-Ouverte/blob/master/LO.md</alt>
           <alt>https://raw.githubusercontent.com/DISIC/politique-de-contribution-open-source/master/LICENSE</alt>


### PR DESCRIPTION
References for the URI change:
- https://github.com/spdx/license-list-data/blob/main/accessingLicenses.md#forming-the-urls:
- https://github.com/spdx/license-list-data/blob/main/rdfturtle/etalab-2.0.ttl
- https://spdx.dev/wp-content/uploads/sites/31/2023/09/spdx-1_2.pdf, section 4.13